### PR TITLE
Better handle case where `tkinter` cannot be imported

### DIFF
--- a/cadence/__init__.py
+++ b/cadence/__init__.py
@@ -5,4 +5,3 @@ from .api.functions import (
 )
 from .api.config import Config as Config
 from .api.track import Track as Track
-from .ui.run import run as run

--- a/cadence/cli/cli.py
+++ b/cadence/cli/cli.py
@@ -1,7 +1,6 @@
 import sys
 
 from cadence.api.functions import load_project, play, play_sound_file
-from cadence.ui.run import run
 
 USAGE = """
 Usage: cadence [go|load|play] <options>
@@ -25,6 +24,8 @@ def main():
     """
     args = sys.argv[1:]
     if not args or args[0] in {"run", "launch", "lancer", "go"}:
+        # Avoid loading UI dependencies unless needed
+        from cadence.ui.run import run
         run()
     elif args[0] in {"load"}:
         if len(args) != 2:
@@ -32,6 +33,7 @@ def main():
             print_usage()
             sys.exit(1)
         file_path = args[1]
+        from cadence.ui.run import run
         run(project_path=file_path)
         pass
 

--- a/cadence/ui/check_tkinter.py
+++ b/cadence/ui/check_tkinter.py
@@ -1,0 +1,43 @@
+import os
+from pathlib import Path
+import sys
+
+
+def check_tkinter():
+    """
+    Check if tkinter is available. If not, try to set environment variables to fix it.
+    If it still fails, raise an error with instructions.
+    """
+
+    try:
+        import tkinter as _
+    except ModuleNotFoundError:
+        # Sometimes tkinter paths are not set correctly in virtual environments
+        # We can try to fix this by setting the path manually but it might not work
+        # TODO: Below fix only works for Mac in any case, need to make cross-platform
+        # Reference: https://github.com/astral-sh/uv/issues/7036
+        os.environ["TCL_LIBRARY"] = str(Path(sys.base_prefix) / "lib" / "tcl8.6")
+        os.environ["TK_LIBRARY"] = str(Path(sys.base_prefix) / "lib" / "tk8.6")
+        try:
+            import tkinter as _
+        except ModuleNotFoundError:
+            which_python = Path(sys.executable).resolve()
+            raise RuntimeError(f"""
+
+Error: tkinter (Python's GUI library) could not be loaded.
+
+You may need to install tkinter separately if it was not included
+with your Python installation.
+
+If you're on Mac and you've installed Python via Homebrew,
+then you can install tkinter with:
+
+    $ brew install python-tk      # or possibly python-tk@3.x for your version of Python
+
+On Debian-based systems (like Ubuntu), you can install it with:
+
+    $ sudo apt-get install python3-tk
+
+This installation of Python is located at:
+{which_python}
+""")

--- a/cadence/ui/run.py
+++ b/cadence/ui/run.py
@@ -1,12 +1,8 @@
-# =====
-# From https://github.com/astral-sh/uv/issues/7036
-from os import environ
 from pathlib import Path
-from sys import base_prefix
 
-environ["TCL_LIBRARY"] = str(Path(base_prefix) / "lib" / "tcl8.6")
-environ["TK_LIBRARY"] = str(Path(base_prefix) / "lib" / "tk8.6")
-# =====
+# Before importing customtkinter, ensure tkinter is available
+from cadence.ui.check_tkinter import check_tkinter
+check_tkinter()
 
 import customtkinter
 


### PR DESCRIPTION
- Show clear error message when `tkinter` fails to import, with instructions for how to fix
- Refactor such that `tkinter` is only imported when launching the GUI (so that other features of the library can still be used even if `tkinter` can't be imported